### PR TITLE
Fix description gaps for last item in advantages list

### DIFF
--- a/src/css/advantages.css
+++ b/src/css/advantages.css
@@ -126,6 +126,11 @@
         gap: 8px;
         min-height: 125px;
     }
+
+    .advantages-item:nth-child(3) .advantages-picture-info {
+        justify-content: inherit;
+        min-height: auto;
+    }
 }
 
 @media screen and (min-width: 1440px) {


### PR DESCRIPTION
Since last element in this list have specific rules of appearance it should not have common justify-content and min-hight attributes so they being removed.